### PR TITLE
PAI-47 section component styles update

### DIFF
--- a/blocks/section/section.css
+++ b/blocks/section/section.css
@@ -1,0 +1,43 @@
+.section[data-backgroundcolor="section--background-color-grey"] {
+    background-color: var(--c-gray-lt);
+}
+
+.section[data-backgroundcolor="section--background-color-white"] {
+    background-color: var(--c-white);
+}
+
+.section[data-alignment="section--text-align-left"] {
+    text-align: left;
+}
+
+.section[data-alignment="section--text-align-center"] {
+    text-align: center;
+}
+
+.section[data-alignment="section--text-align-right"] {
+    text-align: right;
+}
+
+.section[data-maxwidth="section--site-width"] {
+    margin: 0 auto;
+    max-width: 1188px;
+}
+
+.section[data-maxwidth="section--site-width-984px"] {
+    margin: 0 auto;
+    max-width: 984px;
+}
+
+.section[data-maxwidth="section--site-width-800px"] {
+    margin: 0 auto;
+    max-width: 800px;
+}
+
+.section[data-maxwidth="section--site-width-680px"] {
+    margin: 0 auto;
+    max-width: 680px;
+}
+
+.section[data-padding="section--no-padding"] {
+    padding: 0;
+}

--- a/component-models.json
+++ b/component-models.json
@@ -269,12 +269,33 @@
             "value": "section--site-width"
           },
           {
-            "name": "Maximum 680px",
-            "value": "section--site-width-680px"
-          },
-          {
             "name": "Maximum 984px",
             "value": "section--site-width-984px"
+          },
+          {
+            "name": "Maximum 800px",
+            "value": "section--site-width-800px"
+          },
+          {
+            "name": "Maximum 680px",
+            "value": "section--site-width-680px"
+          }
+        ]
+      },
+      {
+        "component": "select",
+        "name": "padding",
+        "value": "",
+        "label": "No Padding",
+        "valueType": "string",
+        "options": [
+          {
+            "name": "Default",
+            "value": ""
+          },
+          {
+            "name": "Zero Padding",
+            "value": "section--no-padding"
           }
         ]
       },

--- a/component-models.json
+++ b/component-models.json
@@ -286,7 +286,7 @@
         "component": "select",
         "name": "padding",
         "value": "",
-        "label": "No Padding",
+        "label": "Padding",
         "valueType": "string",
         "options": [
           {
@@ -294,7 +294,7 @@
             "value": ""
           },
           {
-            "name": "Zero Padding",
+            "name": "No Padding",
             "value": "section--no-padding"
           }
         ]

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -380,19 +380,12 @@ h6 {
 ============================================= */
 /* sections */
 main .section {
-  padding: 64px 16px;
+  padding: 64px 24px;
 }
 
-@media (width >= 600px) {
+@media (width >= 1025) {
   main .section {
-    padding: 64px 32px;
-  }
-}
-
-@media (width >= 900px) {
-  .section > div {
-    max-width: 1200px;
-    margin: auto;
+    padding: 120px 32px;
   }
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>
Added styles for backgrond color , alignment , maxwidth
Added default padding for section for desktop and mobile
Added an option to remove the padding for section

Test URLs:

- Before: https://main--pricefx-eds--pricefx.hlx.live/
- After: https://feature-pai-47-fe-sections--pricefx-eds--pricefx.hlx.page/en
