### PR TITLE
feat: PAI 45 added rounded corner for image1

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -60,6 +60,23 @@
         "name": "alt",
         "value": "Default alt",
         "label": "Alt Text"
+      },
+      {
+        "component": "select",
+        "name": "roundedCorner",
+        "value": "",
+        "label": "Image Rounded Corner",
+        "valueType": "string",
+        "options": [
+          {
+            "name": "Default",
+            "value": ""
+          },
+          {
+            "name": "Rounded Corner",
+            "value": "image--rounded-corner"
+          }
+        ]
       }
     ]
   },

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -231,6 +231,7 @@ figure {
 
 img {
   display: block;
+  height: auto;
   max-width: 100%;
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -416,22 +416,22 @@ main .section.highlight {
   text-align: right;
 }
 
-.section[data-maxwidth="section--site-width"] .default-content-wrapper {
+.section[data-maxwidth="section--site-width"] > div {
   margin: 0 auto;
   max-width: 1188px;
 }
 
-.section[data-maxwidth="section--site-width-984px"] .default-content-wrapper {
+.section[data-maxwidth="section--site-width-984px"] > div {
   margin: 0 auto;
   max-width: 984px;
 }
 
-.section[data-maxwidth="section--site-width-800px"] .default-content-wrapper {
+.section[data-maxwidth="section--site-width-800px"] > div {
   margin: 0 auto;
   max-width: 800px;
 }
 
-.section[data-maxwidth="section--site-width-680px"] .default-content-wrapper {
+.section[data-maxwidth="section--site-width-680px"] > div {
   margin: 0 auto;
   max-width: 680px;
 }
@@ -440,3 +440,7 @@ main .section.highlight {
   padding: 0;
 }
 
+/* image styles */
+img[data-roundedcorner="image--rounded-corner"] {
+  border-radius: 8px;
+}


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>
Added rounded corner variation for image,
For some divs inside section component, .default-content-wrapper is not appended in this case the styles are not applied.
So added the styles to direct child div.
Test URLs:

- Before: https://main--pricefx-eds--pricefx.hlx.live/
- After: https://feature-pai-45-fe-image1--pricefx-eds--pricefx.hlx.page
