### PR TITLE
feat: image style variation added

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -379,7 +379,7 @@
         "component": "select",
         "name": "roundedCorner",
         "value": "",
-        "label": "Image Type",
+        "label": "Rounded Corner for Image/Video",
         "valueType": "string",
         "options": [
           {
@@ -387,8 +387,16 @@
             "value": ""
           },
           {
-            "name": "Rounded Corner",
-            "value": "rounded-corner"
+            "name": "Small",
+            "value": "rounded-corner-8px"
+          },
+          {
+            "name": "Medium",
+            "value": "rounded-corner-16px"
+          },
+          {
+            "name": "Large",
+            "value": "rounded-corner-20px"
           }
         ]
       },

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -391,6 +391,14 @@ main .section.highlight {
 }
 
 /* section image styles */
-.section[data-roundedcorner="rounded-corner"] img {
+.section[data-roundedcorner="rounded-corner-8px"] img {
   border-radius: 8px;
+}
+
+.section[data-roundedcorner="rounded-corner-16px"] img {
+  border-radius: 16px;
+}
+
+.section[data-roundedcorner="rounded-corner-20px"] img {
+  border-radius: 20px;
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>
Added variations for image border
Test URLs:

- Before:  https://main--pricefx-eds--pricefx.hlx.live/
- After: https://feature-pai-45-fe-image4--pricefx-eds--pricefx.hlx.live/
