### PR TITLE
Feature/PAI-9 FE Updated component-models.js for button-pfx to add author option for Tertiary button arrow variant

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -258,6 +258,23 @@
             "value": "tertiary-lt-underline"
           }
         ]
+      },
+      {
+        "component": "select",
+        "name": "classes",
+        "value": "right-arrow",
+        "label": "Tertiary Arrow Variant",
+        "valueType": "string",
+        "options": [
+          {
+            "name": "Right Arrow",
+            "value": "right-arrow"
+          },
+          {
+            "name": "Left Arrow",
+            "value": "left-arrow"
+          }
+        ]
       }
     ]
   },

--- a/component-models.json
+++ b/component-models.json
@@ -206,7 +206,7 @@
         "component": "select",
         "name": "classes",
         "value": "primary",
-        "label": "Variant",
+        "label": "Button Variant",
         "valueType": "string",
         "options": [
           {


### PR DESCRIPTION
Updated the `component-models.json` file for `button-pfx` to add author option for Tertiary button arrow variant. Would like this merged into `main` first before I can start modifying the CSS and do testing.

Test URLs:

- Before: https://main--pricefx-eds--pricefx.hlx.live/
- After: https://feature-pai-9-fe-button-styling--pricefx-eds--pricefx.hlx.live/
