### PR TITLE
Feature/PAI-38 BE Learning Center

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -1077,6 +1077,13 @@
         "valueType": "string"
       },
       {
+        "component": "text",
+        "name": "authorPath",
+        "label": "Author Directory Path",
+        "valueType": "string",
+        "description": "Please enter the path to the author directory."
+      },
+      {
         "component": "number",
         "name": "numberOfArticles",
         "label": "Number Of Articles Display",
@@ -1084,13 +1091,15 @@
         "value": 0
       },
       {
-        "component": "radio-group",
+        "component": "checkbox-group",
         "label": "Sort By",
         "name": "sortBy",
-        "valueType": "string",
+        "valueType": "string[]",
         "options": [
-          { "name": "Asc", "value": "Ascending" },
-          { "name": "Desc", "value": "Descending" }
+          { "name": "Asc Date", "value": "asc-date" },
+          { "name": "Desc Date", "value": "desc-date" },
+          { "name": "Asc Title", "value": "asc-title" },
+          { "name": "Desc Title", "value": "desc-title" }
         ]
       },
       {


### PR DESCRIPTION
Made some adjustment to the `component-models.json` for Learning Center to add author field for author directory path and adjusted the Sort By authoring experience to Checkbox to allow multiple Sort By options (since Radio Group only allows for 1 option).

![Screenshot 2024-04-25 at 5 08 07 PM](https://github.com/pricefx/pricefx-eds/assets/70045188/fc6ab820-1f2f-4ee1-9364-605f28dc1ccd)

Test URLs:

- Before: https://main--pricefx-eds--pricefx.hlx.live/
- After: https://feature-pai-38-be-learning-center--pricefx-eds--pricefx.hlx.live/
