### PR TITLE
fix(pai-144): Fix Fragment Loading Issue on Author Pages

### DIFF
--- a/blocks/fragment/fragment.js
+++ b/blocks/fragment/fragment.js
@@ -6,7 +6,6 @@
 
 import { decorateMain } from '../../scripts/scripts.js';
 import { loadBlocks } from '../../scripts/aem.js';
-import { environmentMode } from '../../scripts/global-functions.js';
 
 /**
  * Loads a fragment.
@@ -15,7 +14,8 @@ import { environmentMode } from '../../scripts/global-functions.js';
  */
 export async function loadFragment(path) {
   if (path && path.startsWith('/')) {
-    const resp = await fetch(`${path}.plain.html`);
+    const fragmentPath = path.replace(/\.html$/, '');
+    const resp = await fetch(`${fragmentPath}.plain.html`);
     if (resp.ok) {
       const main = document.createElement('main');
       main.innerHTML = await resp.text();
@@ -46,11 +46,7 @@ export default async function decorate(block) {
     const fragmentSection = fragment.querySelector(':scope .section');
     if (fragmentSection) {
       block.closest('.section').classList.add(...fragmentSection.classList);
-      if (!environmentMode() === 'publish') {
-        block.closest('.fragment').append(...fragment.childNodes);
-      } else {
-        block.closest('.fragment').replaceWith(...fragment.childNodes);
-      }
+      block.closest('.fragment').append(...fragment.childNodes);
     }
   }
 }


### PR DESCRIPTION
This pull request addresses issues related to loading fragments on author pages, as reported in PAI-144.

Changes Made:

- Modified the code to exclude the ".html" extension from the fragment path to ensure proper loading.
- Updated the logic to clean the path before loading the fragment
- Tested the changes to confirm resolution of the reported problem on author pages.

Fix #[PAI-144](https://bounteous.jira.com/browse/PAI-144)

Test URLs:

- Before: https://main--pricefx-eds--pricefx.hlx.live/
- After: https://bugfix-pai-144-fragment-author--pricefx-eds--pricefx.hlx.live/learning-center/article-1
