### PR TITLE
Bugfix/pai 47 section button inline

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-medium);
+  word-break: break-word;
 }
 
 .columns > div:not(:last-child) {

--- a/component-models.json
+++ b/component-models.json
@@ -946,6 +946,12 @@
       },
       {
         "component": "boolean",
+        "label": "Section buttons inline",
+        "name": "sectionButtonInline",
+        "valueType": "boolean"
+      },
+      {
+        "component": "boolean",
         "label": "Iframe Two Column",
         "name": "iframeTwoColumn",
         "valueType": "boolean"

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -455,6 +455,7 @@ button.tertiary {
   line-height: var(--base-font-size);
   letter-spacing: 0.889px;
   text-transform: uppercase;
+  background: transparent;
 }
 
 a.button.tertiary::after,
@@ -651,6 +652,12 @@ main .section.highlight {
 
 .section[data-iframetwocolumn="true"] >  div:nth-child(2) {
   margin-top: 0;
+}
+
+.section[data-sectionbuttoninline="true"] .button-wrapper,
+.section[data-sectionbuttoninline="true"] .button-pfx-wrapper {
+  display: inline-block;
+  margin-right: 10px;
 }
 
 @media (width >= 768px) {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -654,7 +654,7 @@ main .section.highlight {
   margin-top: 0;
 }
 
-.section[data-sectionbuttoninline="true"] .button-wrapper,
+.section[data-sectionbuttoninline="true"] .button-container,
 .section[data-sectionbuttoninline="true"] .button-pfx-wrapper {
   display: inline-block;
   margin-right: 10px;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>
Section Button to be inline
Test URLs:
https://author-p131512-e1282665.adobeaemcloud.com/ui#/@pricefx/aem/universal-editor/canvas/author-p131512-e1282665.adobeaemcloud.com/content/pricefx/style-guide/components/button.html?ref=bugfix-pai-47-section-button-inline
- Before: https://main--pricefx-eds--pricefx.hlx.live/
- After: https://bugfix-pai-47-section-button-inline--pricefx-eds--pricefx.hlx.page/style-guide/components/button
