### PR TITLE
Feature/PAI-70 FE Learning Center

### DIFF
--- a/blocks/learning-center/learning-center.js
+++ b/blocks/learning-center/learning-center.js
@@ -130,7 +130,8 @@ export default async function decorate(block) {
   // Fetch Articles content from JSON endpoint
   const articleData = await ffetch(searchPath.textContent.trim()).all();
 
-  const featuredArticlePath = featuredArticle.textContent.trim().split('/en')[1];
+  const deconstructFeaturedArticlePath = featuredArticle.textContent.trim().split('/');
+  const featuredArticlePath = deconstructFeaturedArticlePath[deconstructFeaturedArticlePath.length - 1];
   const featuredArticleData = articleData.find((data) => data.path.includes(featuredArticlePath));
   const noFeaturedArticleData = articleData.filter((data) => !data.path.includes(featuredArticlePath));
   const defaultSortedArticle = noFeaturedArticleData.sort(


### PR DESCRIPTION
Since the path to Learning Center is constantly changing due to debugging migration issue, I reworked the `featuredArticlePath` value to take into account potential prefix change that leads up to the article path. This should at least unblock the entire block not rendering articles if the `featuredArticlePath` didn't match `/learning-center` in the url.

Test URLs:

- Before: https://main--pricefx-eds--pricefx.hlx.live/
- After: https://feature-pai-70-learning-center-filter--pricefx-eds--pricefx.hlx.live/style-guide/components/learning-center
