### PR TITLE
Feature/PAI-38 BE Learning Center

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -1560,6 +1560,11 @@
     "id": "learningCenter",
     "fields": [
       {
+        "component": "tab",
+        "label": "Configs",
+        "name": "configs"
+      },
+      {
         "component": "aem-content",
         "name": "featuredArticle",
         "value": "",
@@ -1617,6 +1622,54 @@
             ]
           }
         ]
+      },
+      {
+        "component": "text",
+        "name": "articlesContentCta",
+        "label": "Articles Cards CTA Label",
+        "valueType": "string"
+      },
+      {
+        "component": "text",
+        "name": "ebooksContentCta",
+        "label": "E-Books Cards CTA Label",
+        "valueType": "string"
+      },
+      {
+        "component": "text",
+        "name": "podcastsContentCta",
+        "label": "Podcasts Cards CTA Label",
+        "valueType": "string"
+      },
+      {
+        "component": "text",
+        "name": "caseStudyContentCta",
+        "label": "Case Study Cards CTA Label",
+        "valueType": "string"
+      },
+      {
+        "component": "text",
+        "name": "videosContentCta",
+        "label": "Videos Cards CTA Label",
+        "valueType": "string"
+      },
+      {
+        "component": "text",
+        "name": "reportsContentCta",
+        "label": "Analyst Reports Cards CTA Label",
+        "valueType": "string"
+      },
+      {
+        "component": "text",
+        "name": "defaultContentCta",
+        "label": "Default Cards CTA Label",
+        "valueType": "string",
+        "description": "This will be used as a fallback label in case an article card is missing a content type indicator or doesn't match the provided content types."
+      },
+      {
+        "component": "tab",
+        "label": "Filters",
+        "name": "filters"
       },
       {
         "component": "text-input",


### PR DESCRIPTION
**Updated component-models.json for Learning Center:**
- Added tabs to divide configs and filters authoring
- Added new authoring fields for article cards CTA label

Test URLs:

- Before: https://main--pricefx-eds--pricefx.hlx.live/
- After: https://feature-pai-38-be-learning-center--pricefx-eds--pricefx.hlx.live/
