### PR TITLE
fix(pai-203): fixed regex to handle url without query param

### DIFF
--- a/scripts/editor-support-article.js
+++ b/scripts/editor-support-article.js
@@ -34,7 +34,7 @@ function postReadTime(readingTime, contentPath) {
       },
     ],
     target: {
-      resource: `urn:aemconnection:${contentPath.replace(window.location.origin, '').replace(/\.html\?.*$/, '')}/jcr:content`,
+      resource: `urn:aemconnection:${contentPath.replace(window.location.origin, '').replace(/\.html(\?.*)?$/, '')}/jcr:content`,
       type: 'component',
       prop: '',
     },


### PR DESCRIPTION
This pull request introduces a new feature to calculate and display the estimated reading time for articles in the Universal Editor. Here are the key changes:

- Reading Time Calculation: Implemented a new algorithm to calculate reading time based on the average adult reading speed (250 words per minute).
- Integration with Universal Editor: Integrated the reading time calculation into the Universal Editor's event listeners to automatically update the reading time whenever an article is modified or updated.
- Display of Reading Time: Updated the Page Metadata UI to display the estimated reading time in the format minutes
- POST Request with Reading Time: Implemented functionality to make a POST request to update the reading time data in the backend after each modification.

Test URL: [Universal Editor Test URL](https://author-p131512-e1282665.adobeaemcloud.com/ui#/@pricefx/aem/universal-editor/canvas/author-p131512-e1282665.adobeaemcloud.com/content/pricefx/en/learning-center/10-cool-things-your-business-can-do-with-dynamic-pricing.html?ref=feature-pai-203-article-read-time)

Feature #[PAI-203](https://bounteous.jira.com/browse/PAI-203)

Test URLs:

- Before: https://main--pricefx-eds--pricefx.hlx.live/learning-center/10-cool-things-your-business-can-do-with-dynamic-pricing
- After: https://feature-pai-203-article-read-time--pricefx-eds--pricefx.hlx.live/learning-center/10-cool-things-your-business-can-do-with-dynamic-pricing