### PR TITLE
feat: pai 75 drift chat bot integration

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -8,7 +8,7 @@ sampleRUM('cwv');
 // add more delayed functionality here
 
 // Load Drift Widget
-function LoadDriftChatWidget() {
+function loadDriftChatWidget() {
   const driftChatWidget = document.createRange().createContextualFragment(`
         <!-- Start of Async Drift Code -->
         <script>
@@ -125,6 +125,6 @@ if (!window.location.hostname.includes('localhost') && environmentMode() === 'pu
   loadGTM();
 
   // Load Drift Chat Widget & Events
-  LoadDriftChatWidget();
+  loadDriftChatWidget();
   dirftChatEventListener();
 }

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -7,6 +7,94 @@ sampleRUM('cwv');
 
 // add more delayed functionality here
 
+// Load Drift Widget
+function LoadDriftChatWidget() {
+  const driftChatWidget = document.createRange().createContextualFragment(`
+        <!-- Start of Async Drift Code -->
+        <script>
+            "use strict";
+            !function() {
+            var t = window.driftt = window.drift = window.driftt || [];
+            if (!t.init) {
+                if (t.invoked) return void (window.console && console.error && console.error("Drift snippet included twice."));
+                t.invoked = !0, t.methods = [ "identify", "config", "track", "reset", "debug", "show", "ping", "page", "hide", "off", "on" ], 
+                t.factory = function(e) {
+                return function() {
+                    var n = Array.prototype.slice.call(arguments);
+                    return n.unshift(e), t.push(n), t;
+                };
+                }, t.methods.forEach(function(e) {
+                t[e] = t.factory(e);
+                }), t.load = function(t) {
+                var e = 3e5, n = Math.ceil(new Date() / e) * e, o = document.createElement("script");
+                o.type = "text/javascript", o.async = !0, o.crossorigin = "anonymous", o.src = "https://js.driftt.com/include/" + n + "/" + t + ".js";
+                var i = document.getElementsByTagName("script")[0];
+                i.parentNode.insertBefore(o, i);
+                };
+            }
+            }();
+            drift.SNIPPET_VERSION = '0.3.1';
+            drift.load('69rfc67t5vkt');
+        </script>
+        <!-- End of Async Drift Code -->
+    `);
+  document.head.append(driftChatWidget);
+}
+
+function dirftChatEventListener() {
+  const chatWidgetEvents = document.createRange().createContextualFragment(`
+        <!-- Start of Drift Events -->
+        <script type="text/javascript">
+            (function() {
+                /* Add this class to any elements you want to use to open Drift.
+                *
+                * Examples:
+                * - <a class="drift-open-chat">Questions? We're here to help!</a>
+                * - <button class="drift-open-chat">Chat now!</button>
+                *
+                * You can have any additional classes on those elements that you
+                * would like.
+                */
+                var DRIFT_CHAT_SELECTOR = '[href*="#chatwithus"]'
+                /* http://youmightnotneedjquery.com/#ready */
+                function ready(fn) {
+                    if (document.readyState != 'loading') {
+                    fn();
+                    } else if (document.addEventListener) {
+                    document.addEventListener('DOMContentLoaded', fn);
+                    } else {
+                    document.attachEvent('onreadystatechange', function() {
+                        if (document.readyState != 'loading')
+                        fn();
+                    });
+                    }
+                }
+                /* http://youmightnotneedjquery.com/#each */
+                function forEachElement(selector, fn) {
+                    var elements = document.querySelectorAll(selector);
+                    for (var i = 0; i < elements.length; i++)
+                    fn(elements[i], i);
+                }
+                function openChat(driftApi, event) {
+                    event.preventDefault();
+                    driftApi.openChat();
+                    return false;
+                }
+                ready(function() {
+                    drift.on('ready', function(api) {
+                    var handleClick = openChat.bind(this, api)
+                    forEachElement(DRIFT_CHAT_SELECTOR, function(el) {
+                        el.addEventListener('click', handleClick);
+                    });
+                    });
+                });
+            })();
+        </script>
+        <!-- End of Drift Events -->
+    `);
+  document.head.append(chatWidgetEvents);
+}
+
 // Google tag manager
 function loadGTM() {
   const scriptTag = document.createElement('script');
@@ -35,4 +123,8 @@ function loadGTM() {
 if (!window.location.hostname.includes('localhost') && environmentMode() === 'publish') {
   // Load GTM
   loadGTM();
+
+  // Load Drift Chat Widget & Events
+  LoadDriftChatWidget();
+  dirftChatEventListener();
 }


### PR DESCRIPTION
This PR includes the integration of Drift Chat Bot Widget and Events added for the `Chat with us` button.
The link which is having the `#chatwithus` href value will open the Chat bot.

Fix #<[PAI-75](https://bounteous.jira.com/browse/PAI-75)>

Test URLs:

- Before: https://main--pricefx-eds--pricefx.hlx.live/
- After: https://feature-pai-75-drift-chat-bot-integration--pricefx-eds--pricefx.hlx.live/style-guide/components/hero