### PR TITLE
Bugfix/PAI-66 FE Carousel

### DIFF
--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -1,6 +1,6 @@
 /* stylelint-disable no-descending-specificity */
 /* QUOTE CAROUSEL STYLES */
-main:has(.carousel[data-carousel-type='carousel-quote']) p {
+main .carousel:has(.carousel[data-carousel-type='carousel-quote']) .carousel > p {
  text-align: left;
 }
 


### PR DESCRIPTION
The styling applied to the `p` element in Carousel with quote was affecting other `p` element outside of carousel. Added specificity to the selector to only target `p` element within Carousel quote.

Test URLs:

- Before: https://main--pricefx-eds--pricefx.hlx.live/
- After: https://feature-pai-66-fe-carousel--pricefx-eds--pricefx.hlx.live/style-guide/components/carousel
