### PR TITLE
Feature/PAI-164 Second Level Header Link

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -130,13 +130,13 @@ header nav {
   width: 100%;
 }
 
-.nav-list-level-2-item:last-child {
+.nav-list-level-2-item:has(.level-2-item-link--sign-in) {
   margin-right: 0;
 }
 
-.nav-list-level-2-2 .nav-list-level-2-item:last-child {
+.nav-list-level-2-2 .nav-list-level-2-item:nth-last-child(-n + 3) {
   grid-column: 4;
-  margin: var(--spacing-xsmall) 0 0 0;
+  margin: 0 0 5px;
 }
 
 .nav-list-level-2-item-category,
@@ -146,6 +146,11 @@ header nav {
   font-size: var(--body-font-size-m);
   font-weight: var(--fw-x-bold);
   padding-bottom: 15px;
+}
+
+.level-2-item-link--sign-in {
+  border-bottom: none;
+  padding: 0;
 }
 
 .nav-list-level-2-5 .category:nth-child(5) {
@@ -161,11 +166,11 @@ header nav {
   font-size: var(--body-font-size-m);
   font-weight: var(--fw-regular);
   left: auto;
-  max-width: 380px;
+  max-width: 450px;
   min-width: 355px;
   padding: var(--spacing-xlarge) var(--spacing-jumbo);
   transform: translateX(-128px);
-  width: 100%;
+  width: auto;
 }
 
 .megamenu-wrapper:has(li.no-category) .nav-list-level-2 {
@@ -179,11 +184,6 @@ header nav {
 
 .no-category-wrapper {
   margin: 0 40px var(--spacing-xxsmall) 0;
-}
-
-.no-category-wrapper + .nav-list-level-2-item .level-2-item-link {
-  border-bottom: none;
-  padding: 0;
 }
 
 .megamenu-wrapper:has(li.no-category) li.no-category:last-child {
@@ -442,11 +442,16 @@ header nav {
 }
 
 .nav-mobile-list-level-2-category::before,
+.nav-mobile-list-level-2-category .nav-mobile-list-level-2-category-link,
 .nav-mobile-list-level-2-category-link {
   color: var(--c-white);
   content: attr(aria-label);
   font-size: var(--body-font-size-m);
   font-weight: var(--fw-bold);
+}
+
+.nav-mobile-list-level-2-item {
+  margin-bottom: 0;
 }
 
 .nav-mobile-list-level-2-item a,
@@ -483,10 +488,6 @@ header nav {
 .nav-mobile-list-level-2-category-link:hover,
 .nav-mobile-list-level-2-category-link:focus {
   text-decoration: none;
-}
-
-.nav-mobile-list-level-2-category-link:last-child {
-  margin-bottom: 0;
 }
 
 header a:hover,
@@ -561,7 +562,7 @@ header a:focus {
 /* Responsive Styling */
 @media (width <= 1199px) {
   header nav {
-    padding-left: 0;
+    padding: 0;
   }
 
   .megamenu-wrapper {

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -208,9 +208,18 @@ export default async function decorate(block) {
       if (level2Label.includes('|')) {
         const linkInfoArray = level2Label.split('|');
         markup += `
-          <li class="nav-list-level-2-item">
-            <a href="${linkInfoArray[1].trim()}" target="${linkInfoArray.length >= 2 ? linkInfoArray[2].trim() : '_self'}" ${linkInfoArray.length >= 2 ? "class='level-2-item-link'" : ''} tabindex="0">${linkInfoArray[0].trim()}</a>
-          </li>
+          ${
+            linkInfoArray[0].trim().includes('Sign In')
+              ? `<li class="nav-list-level-2-item">
+              <a href="${linkInfoArray[1].trim()}" target="${linkInfoArray[2].trim()}" class="level-2-item-link level-2-item-link--sign-in" tabindex="0">${linkInfoArray[0].trim()}</a>
+            </li>`
+              : `<li class="nav-list-level-2-item category">
+              <a href="${linkInfoArray[1].trim()}" target="${linkInfoArray[2].trim()}" class="nav-list-level-2-item-category">${linkInfoArray[0].trim()}</a>
+              <ul class="nav-list-level-3">
+                ${renderLevelThreeItems(level2Label)}
+              </ul>
+            </li>`
+          }
         `;
       } else if (!level2Label.includes('|') && level2Label !== '') {
         markup += `
@@ -310,7 +319,11 @@ export default async function decorate(block) {
     });
 
     navListLevelOne.addEventListener('mouseover', () => {
-      allMegamenu.forEach((megamenu) => megamenu.classList.remove('megamenu-wrapper--active'));
+      navListLevelOne.blur();
+      allMegamenu.forEach((megamenu) => {
+        megamenu.classList.remove('megamenu-wrapper--active');
+        megamenu.addEventListener('mouseout', () => navListLevelOne.blur());
+      });
 
       // Reset Search ADA
       resetSearchCTA(searchToggle);
@@ -457,7 +470,14 @@ export default async function decorate(block) {
       if (level2Label.includes('|')) {
         const linkInfoArray = level2Label.split('|');
         markup += `
-          <a class="nav-mobile-list-level-2-category-link" href="${linkInfoArray[1].trim()}" target="${linkInfoArray.length >= 2 ? linkInfoArray[2].trim() : '_self'}">${linkInfoArray[0].trim()}</a>
+          ${
+            linkInfoArray[0].trim().includes('Sign In')
+              ? `<a class="nav-mobile-list-level-2-category-link" href="${linkInfoArray[1].trim()}" target="${linkInfoArray[2].trim()}">${linkInfoArray[0].trim()}</a>`
+              : `<ul class="nav-mobile-list-level-2-category">
+              <a class="nav-mobile-list-level-2-category-link" href="${linkInfoArray[1].trim()}" target="${linkInfoArray[2].trim()}">${linkInfoArray[0].trim()}</a>
+              ${renderMobileLevelThreeItems(level2Label)}
+            </ul>`
+          }
         `;
       } else if (!level2Label.includes('|') && level2Label !== '') {
         markup += `


### PR DESCRIPTION
This PR includes the following:
- PAI-164: Enable links for 2nd level header navigations
- PAI-148: Bugfix for megamenu staying in focus when user hovers over another 1st level navigation
- PAI-217: Bugfix for style issues of single column megamenu and overlapping 2nd level links in "Our Software" megamenu

Test URLs:

- Before: https://main--pricefx-eds--pricefx.hlx.live/
- After: https://feature-pai-164-second-level-header-link--pricefx-eds--pricefx.hlx.live/
