### PR TITLE
feat: added process url global function

### DIFF
--- a/scripts/global-functions.js
+++ b/scripts/global-functions.js
@@ -152,11 +152,6 @@ function replaceDomain(url, env) {
  * @param {string} url - The incoming URL or path.
  * @returns {string} - The processed URL.
  */
-/**
- * Process the incoming URL and prepend the appropriate domain based on the environment.
- * @param {string} url - The incoming URL or path.
- * @returns {string} - The processed URL.
- */
 function processUrl(url) {
   const env = getEnvironment();
   if (environmentMode() === 'publish' && env) {

--- a/scripts/global-functions.js
+++ b/scripts/global-functions.js
@@ -47,5 +47,102 @@ const replaceBasePath = (isPublishEnvironment, pagePath, baseContentPath) => {
   return null;
 };
 
+/**
+ * Get the appropriate domain for a given environment.
+ * @param {string} env - The environment identifier.
+ * @returns {string} - The corresponding domain or an empty string for relative URLs.
+ */
+function getEnvironmentDomain(env) {
+  switch (env) {
+    case 'pricefx-eds':
+      return 'https://publish-p131512-e1282665.adobeaemcloud.com';
+    case 'pricefx-eds-qa':
+      return 'https://publish-p131512-e1282669.adobeaemcloud.com';
+    case 'pricefx-eds-stage':
+      return 'https://publish-p131512-e1282667.adobeaemcloud.com';
+    case 'pricefx-eds-prod':
+      return 'https://publish-p131512-e1282666.adobeaemcloud.com';
+    case 'pricefx.com':
+    case 'preview.pricefx.com':
+      return ''; // Return empty string for relative URL
+    default:
+      return '';
+  }
+}
+
+/**
+ * Determine if the domain should be prepended based on the URL path and its extension.
+ * @param {string} url - The incoming URL or path.
+ * @returns {boolean} - True if the domain should be prepended, false otherwise.
+ */
+function shouldPrependDomain(url) {
+  const validExtensions = ['.mp3', '.zip', '.docx'];
+  const startsWithContentDam = url.startsWith('/content/dam/pricefx');
+  const hasValidExtension = validExtensions.some((ext) => {
+    const regex = new RegExp(`${ext}(\\?|$)`);
+    return regex.test(url);
+  });
+
+  return startsWithContentDam && hasValidExtension;
+}
+
+/**
+ * Prepend the appropriate domain to the URL based on the environment.
+ * @param {string} url - The incoming URL or path.
+ * @param {string} env - The environment identifier.
+ * @returns {string} - The URL with the domain prepended if necessary.
+ */
+function prependDomain(url, env) {
+  // Check if the URL starts with "http" and return it if it does.
+  if (url.startsWith('http')) {
+    return url;
+  }
+
+  // If environment is live or preview, return relative URL.
+  if (env === 'pricefx.com' || env === 'preview.pricefx.com') {
+    return url;
+  }
+
+  const domain = getEnvironmentDomain(env);
+  return domain ? `${domain}${url}` : url;
+}
+
+/**
+ * Get the environment identifier from the current environment URL.
+ * @param {string} currentUrl - The current environment URL.
+ * @returns {string} - The environment identifier.
+ */
+function getEnvironment() {
+  const { hostname } = window.location;
+  const envMap = {
+    'pricefx-eds': 'pricefx-eds',
+    'pricefx-eds-qa': 'pricefx-eds-qa',
+    'pricefx-eds-stage': 'pricefx-eds-stage',
+    'pricefx-eds-prod': 'pricefx-eds-prod',
+    'www.pricefx.com': 'pricefx.com',
+    'preview.pricefx.com': 'preview.pricefx.com',
+  };
+
+  const keys = Object.keys(envMap);
+  const result = keys.find((key) => hostname.includes(`--${key}--`) || hostname.includes(key));
+  return result ? envMap[result] : 'pricefx.com'; // Default to live
+}
+
+/**
+ * Process the incoming URL and prepend the appropriate domain based on the environment.
+ * @param {string} url - The incoming URL or path.
+ * @returns {string} - The processed URL.
+ */
+function processUrl(url) {
+  if (environmentMode() === 'publish') {
+    const env = getEnvironment();
+
+    if (shouldPrependDomain(url)) {
+      return prependDomain(url, env);
+    }
+  }
+  return url;
+}
+
 // eslint-disable-next-line import/prefer-default-export
-export { environmentMode, formatDate, sortByDate, replaceBasePath };
+export { environmentMode, formatDate, sortByDate, replaceBasePath, processUrl };

--- a/scripts/global-functions.js
+++ b/scripts/global-functions.js
@@ -140,7 +140,12 @@ function replaceDomain(url, env) {
   if (!domain) {
     return null; // Return null if the environment domain is not defined
   }
-  if (domain && url.startsWith('https://')) {
+  const validExtensions = ['.mp3', '.zip', '.docx'];
+  const hasValidExtension = validExtensions.some((ext) => {
+    const regex = new RegExp(`${ext}(\\?|$)`);
+    return regex.test(url);
+  });
+  if (domain && url.startsWith('https://') && hasValidExtension) {
     const { hostname } = new URL(url);
     return url.replace(hostname, domain);
   }


### PR DESCRIPTION
This commit introduces a function responsible for processing asset paths that need to be served from the publish environment. The function analyzes the hostname of the window location and maps it to the corresponding environment using a predefined environment map. It returns the environment associated with the hostname if found, otherwise defaults to 'pricefx.com' as the live environment."

Test URLs:

- Before: https://main--pricefx-eds--pricefx.hlx.live/
- After: https://feature-process-url--pricefx-eds--pricefx.hlx.live/
