### PR TITLE
Feature/PAI-221 Update iFrame component-models.json

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -1946,11 +1946,16 @@
     "id": "iframe",
     "fields": [
       {
-        "component": "text-input",
-        "valueType": "string",
-        "name": "href",
-        "value": "",
-        "label": "Link"
+        "component": "richtext",
+        "name": "badgeLinks",
+        "label": "Badge Links",
+        "valueType": "string"
+      },
+      {
+        "component": "richtext",
+        "name": "iframeLinks",
+        "label": "iFrame Links",
+        "valueType": "string"
       },
       {
         "component": "text-input",


### PR DESCRIPTION
This PR updates the iFrame `component-models.json`:
- Added RTE for Badge links authoring
- Changed text field to RTE for iFrame links authoring

Test URLs:

- Before: https://main--pricefx-eds--pricefx.hlx.live/
- After: https://bugfix-pai-221-iframe-component-update--pricefx-eds--pricefx.hlx.live/
