### PR TITLE
fix(pai-142): fixed js error with updateMetadata function

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -123,9 +123,18 @@ function buildAutoBlocks() {
 }
 
 async function updateMetadata() {
-  document.title = `${document.title} | Pricefx`;
-  document.head.querySelector('meta[property="og:title"]').content = document.title;
-  document.head.querySelector('meta[name="twitter:title"]').content = document.title;
+  document.title = `${document.title || ''} | Pricefx`;
+
+  const ogTitleMeta = document.head.querySelector('meta[property="og:title"]');
+  const twitterTitleMeta = document.head.querySelector('meta[name="twitter:title"]');
+
+  if (ogTitleMeta) {
+    ogTitleMeta.content = document.title;
+  }
+
+  if (twitterTitleMeta) {
+    twitterTitleMeta.content = document.title;
+  }
 }
 
 /**


### PR DESCRIPTION
This PR addresses a JavaScript error that was occurring while loading the 404 error page. The error was caused by attempts to access properties of null or undefined objects when updating the document's metadata.

Fix: # [PAI-142](https://bounteous.jira.com/browse/PAI-142)

Test URLs:

- Before: https://main--pricefx-eds--pricefx.hlx.live/
- After: https://bugfix-pai-142-404-error--pricefx-eds--pricefx.hlx.live/
