### PR TITLE
Bugfix/PAI-256 Marketo Form Asterix Placement on Mobile

### DIFF
--- a/blocks/marketo-form/marketo-form.css
+++ b/blocks/marketo-form/marketo-form.css
@@ -54,8 +54,16 @@
   height: 22px;
 }
 
+.marketo-form-wrapper .mktoAsterix {
+  display: none !important;
+}
+
+.marketo-form-wrapper .mktoForm .form-asterix {
+  padding-left: 5px;
+}
+
 .marketo-form-wrapper .mktoForm .mktoLabel,
-.marketo-form-wrapper .mktoForm .mktoAsterix,
+.marketo-form-wrapper .mktoForm .form-asterix,
 .marketo-form-wrapper .mktoForm input[type='text'],
 .marketo-form-wrapper .mktoForm input[type='email'],
 .marketo-form-wrapper .mktoForm input[type='tel'],
@@ -287,10 +295,6 @@
 }
 
 @media (width <= 480px) {
-  .marketo-form-wrapper .mktoForm .mktoAsterix {
-    float: right !important;
-  }
-
   .marketo-form-wrapper .mktoForm .mktoLabel {
     margin-bottom: var(--spacing-micro);
   }

--- a/blocks/marketo-form/marketo-form.js
+++ b/blocks/marketo-form/marketo-form.js
@@ -18,9 +18,9 @@ const embedMarketoForm = (marketoId, formId, successUrl, isHideLabels, block, fo
       if (successUrl) {
         window.MktoForms2.loadForm('//lp.pricefx.com', marketoId, formId, (form) => {
           // Add hide form labels class if boolean is true
+          const allFormLabels = formElement.querySelectorAll('label');
           if (isHideLabels === 'true') {
             block.classList.add('form-hide-labels');
-            const allFormLabels = formElement.querySelectorAll('label');
             allFormLabels.forEach((label) => {
               const parentEl = label.parentElement;
               const inputTextEl = parentEl.querySelector('input[type="text"]');
@@ -51,6 +51,13 @@ const embedMarketoForm = (marketoId, formId, successUrl, isHideLabels, block, fo
             });
           } else {
             block.classList.remove('form-hide-labels');
+            allFormLabels.forEach((label) => {
+              const parentEl = label.parentElement;
+              if (parentEl.classList.contains('mktoRequiredField')) {
+                const asterix = '<span class="form-asterix">*</span>';
+                label.insertAdjacentHTML('beforeend', asterix);
+              }
+            });
           }
 
           // Add an onSuccess handler


### PR DESCRIPTION
This PR implements the fix for asterix placement in marketo form label on mobile when labels are very long and breaks into a second line.

Test URLs:

- Before: https://main--pricefx-eds--pricefx.hlx.live/
- After: https://bugfix-pai-256-marketo-form-asterisk-bug--pricefx-eds--pricefx.hlx.live/partners/slalom
