### PR TITLE
fix: do not redecorate blocks

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -650,7 +650,7 @@ async function loadBlocks(main) {
  */
 function decorateBlock(block) {
   const shortBlockName = block.classList[0];
-  if (shortBlockName) {
+  if (shortBlockName && !block.dataset.blockStatus) {
     block.classList.add('block');
     block.dataset.blockName = shortBlockName;
     block.dataset.blockStatus = 'initialized';


### PR DESCRIPTION
With this change blocks don't get redecorated.

Reload of edited sections may break blocks in other sections. To reproduce this, change the style of a section and check if any blocks on the page disappear. They disappear because the decorate() function of the block is called a second time after they have been decorated before and that may break some blocks.

Test URLs:

Before: https://main--pricefx-eds--pricefx.hlx.live/
After: https://dirk-patch-1--pricefx-eds--pricefx.hlx.live/

https://author-p131512-e1282665.adobeaemcloud.com/ui#/@pricefx/aem/universal-editor/canvas/author-p131512-e1282665.adobeaemcloud.com/content/pricefx/en/index.html?ref=dirk-patch-1