### PR TITLE
Bugfix/PAI-305 Learning Center Sort By Date

### DIFF
--- a/blocks/learning-center/learning-center.js
+++ b/blocks/learning-center/learning-center.js
@@ -147,16 +147,23 @@ export default async function decorate(block) {
   const searchUrlPath = searchUrl.pathname;
   const articleData = await ffetch(searchUrlPath).all();
 
+  // Getting the featured article data
   const deconstructFeaturedArticlePath = featuredArticle.split('/');
   const featuredArticlePath = deconstructFeaturedArticlePath[deconstructFeaturedArticlePath.length - 1];
   const featuredArticleData = articleData.find((data) => data.path.includes(featuredArticlePath));
+
+  // Filter out the featured article data from the rest of the article data (if applicable)
   let noFeaturedArticleData;
   if (featuredArticlePath !== '') {
     noFeaturedArticleData = articleData.filter((data) => !data.path.includes(featuredArticlePath));
   } else {
     noFeaturedArticleData = articleData;
   }
-  const defaultSortedArticle = noFeaturedArticleData.sort(
+
+  // Remove article data that has no publish date value (these are parent pages and not articles)
+  // Then sort from latest publish date to oldest
+  const hasPublisheDateArticles = noFeaturedArticleData.filter((data) => data.articlePublishDate !== '');
+  const defaultSortedArticle = hasPublisheDateArticles.sort(
     (a, b) => new Date(b.articlePublishDate) - new Date(a.articlePublishDate),
   );
   let currentArticleData = [...defaultSortedArticle];


### PR DESCRIPTION
This PR fixes the issue for article sorting from newest to oldest.

The issue was caused by some article JSON data having empty `articlePublishDate` value. This would then break the function that was trying to sort through all the dates as it would encounter those empty values. Filtering out any data with empty `articlePublishDate` value fixed the issue. 

Test URLs:

- Before: https://main--pricefx-eds--pricefx.hlx.live/
- After: https://bugfix-pai-305-learning-center-sortby--pricefx-eds--pricefx.hlx.live/learning-center
