### PR TITLE
Bugfix/PAI-306 Partner Showcase Logo Issue

### DIFF
--- a/blocks/partner-showcase/partner-showcase.css
+++ b/blocks/partner-showcase/partner-showcase.css
@@ -242,6 +242,7 @@
 .partner-card .partner-image img {
   border-radius: 8px 8px 0 0;
   display: block;
+  max-height: 140px;
   max-width: 210px;
   width: 100%;
 }


### PR DESCRIPTION
This PR implement a fix to prevent Partner Showcase logo from overflowing the image container.

Test URLs:

- Before: https://main--pricefx-eds--pricefx.hlx.live/
- After: https://bugfix-pai-306-partner-showcase-logo--pricefx-eds--pricefx.hlx.live/style-guide/components/partner-showcase
