### PR TITLE
fix(social-share): provided dark bg for light variant

### DIFF
--- a/blocks/social-share/social-share.css
+++ b/blocks/social-share/social-share.css
@@ -45,6 +45,10 @@
     fill: transparent;
 }
 
+.social-share.social-share-light-theme{
+    background-color: #323232;
+}
+
 /* Resposive Styles */
 @media (width >= 480px) {
     .social-share .a2a_default_style > li:not(:last-child) {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:

- Before: https://main--pricefx-eds--pricefx.hlx.live/
- After: https://feature-pai-156-social-share-dark-bg--pricefx-eds--pricefx.hlx.live/
