### PR TITLE
fix(hero-img): remove lazy loading

### DIFF
--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -143,7 +143,7 @@ export default async function decorate(block) {
   heroRightContainer
     .querySelectorAll('img')
     .forEach((img) =>
-      img.closest('picture').replaceWith(createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }])),
+      img.closest('picture').replaceWith(createOptimizedPicture(img.src, img.alt, true, [{ width: '750' }])),
     );
 
   heroContainer.append(heroLeftContainer);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:

- Before: https://main--pricefx-eds--pricefx.hlx.live/
- After: https://feature-pai-324-img-lazy-loading--pricefx-eds--pricefx.hlx.live/
